### PR TITLE
add missing auto values ('enhance', 'redeye')

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export enum ImgixColorSpace {
 }
 
 // https://docs.imgix.com/apis/url/auto
-export type ImgixAuto = Partial<Record<'compress' | 'format', boolean>>;
+export type ImgixAuto = Partial<Record<'compress' | 'enhance' | 'format' | 'redeye', boolean>>;
 
 // https://docs.imgix.com/apis/url/format/ch
 export type ImgixClientHints = Partial<Record<'width' | 'dpr' | 'saveData', boolean>>;


### PR DESCRIPTION
- omitted 'true' as this is considered deprecated
  and thus should be discouraged from new usage

ref: https://github.com/imgix/imgix-url-params/blob/a0ade6303b1e37ccce5824d5c98618cc45b60b11/dist/parameters.json#L12