### PR TITLE
Add min-h Imgix query param

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,9 @@ import { pickBy } from './helpers';
 import { catMaybesDictionary, mapValueIfDefined } from './helpers/maybe';
 import { pipe } from './helpers/pipe';
 
+// Omit is only available from TS 3.5 onwards
+type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+
 // https://docs.imgix.com/apis/url/size/fit
 export enum ImgixFit {
     clamp = 'clamp',
@@ -71,7 +74,10 @@ export type ImgixUrlQueryParams = {
     cs?: ImgixColorSpace;
     faceindex?: number;
     facepad?: number;
+    'min-h'?: number;
 };
+
+export type QueryParamsInput = Omit<ImgixUrlQueryParams, 'min-h'> & { minH?: number };
 
 const pickTrueInObject = <K extends string>(obj: Record<K, boolean>): Partial<Record<K, true>> =>
     pickBy(obj, (_key, value): value is true => value);
@@ -90,7 +96,7 @@ const serializeImgixUrlQueryParamListValue = pipe(
 
 const mapToSerializedListValueIfDefined = mapValueIfDefined(serializeImgixUrlQueryParamListValue);
 
-const serializeImgixUrlQueryParamValues = (query: ImgixUrlQueryParams): ParsedUrlQueryInput =>
+const serializeImgixUrlQueryParamValues = (query: QueryParamsInput): ParsedUrlQueryInput =>
     pipe(
         (): Record<keyof ImgixUrlQueryParams, string | number | undefined> => ({
             ar: mapValueIfDefined((ar: ImgixAspectRatio) => `${ar.w}:${ar.h}`)(query.ar),
@@ -110,6 +116,7 @@ const serializeImgixUrlQueryParamValues = (query: ImgixUrlQueryParams): ParsedUr
             blur: query.blur,
             faceindex: query.faceindex,
             facepad: query.facepad,
+            'min-h': query.minH,
         }),
         catMaybesDictionary,
     )({});

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -7,6 +7,7 @@ assert.strictEqual(
             format: true,
         },
         w: 300,
+        minH: 300,
     }),
-    'https://foo.com/?auto=format&w=300',
+    'https://foo.com/?auto=format&w=300&min-h=300',
 );


### PR DESCRIPTION
I had to bring in `Omit` since the TS version is 3.2 and upgrading might be a rabbithole (I haven't tried).