### PR TITLE
Add X and Y for Focal Point Crop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,6 +122,9 @@ export type ImgixUrlQueryParams = {
     cs?: ImgixColorSpace;
     faceindex?: number;
     facepad?: number;
+    // Positions X and Y for Focal Point Crop. For these points to be set on an image, fit=crop and crop=focalpoint must also be set.
+    'fp-x'?: number;
+    'fp-y'?: number;
     'fp-z'?: number;
     'min-h'?: number;
     'mark-w'?: number;
@@ -212,6 +215,8 @@ export const buildParams = (query: QueryParamsInput): Record<string, string> => 
         blur: mapValueIfDefined(String)(query.blur),
         faceindex: mapValueIfDefined(String)(query.faceindex),
         facepad: mapValueIfDefined(String)(query.facepad),
+        'fp-x': mapValueIfDefined(String)(query.fpX),
+        'fp-y': mapValueIfDefined(String)(query.fpY),
         'fp-z': mapValueIfDefined(String)(query.fpZ),
         'min-h': mapValueIfDefined(String)(query.minH),
         'mark-w': mapValueIfDefined(String)(query.markW),


### PR DESCRIPTION
While working on https://linear.app/unsplash/issue/CUST-152/web-update-module (https://github.com/unsplash/unsplash-web/pull/11403), I realized we might need extra parameters for some of the imgix images so that we can 'shift them around' (I'm not sure `crop: {faces: true}` cuts it):


![Screenshot 2024-01-11 at 11 27 41](https://github.com/unsplash/ts-imgix/assets/109063037/137352a8-6481-43b3-b535-5570e2e81c75)

Imgix reference here: https://docs.imgix.com/apis/rendering/focalpoint-crop